### PR TITLE
Improve type-stability for array inputs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: julia
 os:
   - linux
-  - osx
 julia:
-  - release
+  - 0.3
+  - 0.4
+  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/src/Subsequences.jl
+++ b/src/Subsequences.jl
@@ -5,6 +5,10 @@ export longest_common_subsequence, longest_contiguous_subsequence
 # -------
 
 function longest_common_subsequence(a, b; result_base = "", join_fn = string)
+    longest_common_subsequence(a, b, result_base, join_fn)
+end
+
+function longest_common_subsequence(a, b, result_base, join_fn)
     lengths = zeros(length(a) + 1, length(b) + 1)
 
     for (i, x) in enumerate(a)
@@ -46,7 +50,7 @@ function longest_common_subsequence(a, b; result_base = "", join_fn = string)
     result, a_start:a_end, b_start:b_end
 end
 
-longest_common_subsequence(a::Array, b::Array) = longest_common_subsequence(a, b, result_base = [], join_fn = vcat)
+longest_common_subsequence{T1, T2}(a::Array{T1}, b::Array{T2}) = longest_common_subsequence(a, b, Vector{promote_type(T1, T2)}(), vcat)
 
 # -------
 

--- a/src/Subsequences.jl
+++ b/src/Subsequences.jl
@@ -56,7 +56,7 @@ end
 # Base.vcat
 prepend{T}(x::T, v::AbstractVector{T}) = vcat([x], v)
 
-longest_common_subsequence{T1, T2}(a::Array{T1}, b::Array{T2}) = longest_common_subsequence(a, b, Vector{promote_type(T1, T2)}(), prepend)
+longest_common_subsequence{T1, T2}(a::Array{T1}, b::Array{T2}) = longest_common_subsequence(a, b, promote_type(T1, T2)[], prepend)
 
 # -------
 

--- a/src/Subsequences.jl
+++ b/src/Subsequences.jl
@@ -8,7 +8,7 @@ function longest_common_subsequence(a, b; result_base = "", join_fn = string)
     longest_common_subsequence(a, b, result_base, join_fn)
 end
 
-function longest_common_subsequence(a, b, result_base, join_fn)
+function longest_common_subsequence{T}(a, b, result_base::T, join_fn)
     lengths = zeros(length(a) + 1, length(b) + 1)
 
     for i in 1:length(a)
@@ -23,7 +23,7 @@ function longest_common_subsequence(a, b, result_base, join_fn)
     end
 
     x, y = length(a) + 1, length(b) + 1
-    result = result_base
+    result::T = result_base
     a_start, a_end = 0, 0
     b_start, b_end = 0, 0
 

--- a/src/Subsequences.jl
+++ b/src/Subsequences.jl
@@ -11,9 +11,10 @@ end
 function longest_common_subsequence(a, b, result_base, join_fn)
     lengths = zeros(length(a) + 1, length(b) + 1)
 
-    for (i, x) in enumerate(a)
-        for (j, y) in enumerate(b)
-            if x == y
+    for i in 1:length(a)
+        ai = a[i]
+        for j in 1:length(b)
+            if ai == b[j]
                 lengths[i+1, j+1] = lengths[i, j] + 1
             else
                 lengths[i+1, j+1] = max(lengths[i+1, j], lengths[i, j+1])
@@ -50,7 +51,12 @@ function longest_common_subsequence(a, b, result_base, join_fn)
     result, a_start:a_end, b_start:b_end
 end
 
-longest_common_subsequence{T1, T2}(a::Array{T1}, b::Array{T2}) = longest_common_subsequence(a, b, Vector{promote_type(T1, T2)}(), vcat)
+# In julia < v0.6, the return type of vcat(x::T, v::Vector{T}) is not
+# inferred correctly, so we explicitly construct [x] before calling
+# Base.vcat
+prepend{T}(x::T, v::AbstractVector{T}) = vcat([x], v)
+
+longest_common_subsequence{T1, T2}(a::Array{T1}, b::Array{T2}) = longest_common_subsequence(a, b, Vector{promote_type(T1, T2)}(), prepend)
 
 # -------
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,24 @@ seq, a_range, b_range = longest_common_subsequence(a, b)
 @test a_range == 1:7
 @test b_range == 4:13
 
+# Test for type-stability with identical element types
+a = [:v, :x, :x, :y, :x, :z, :y, :z]
+b = [:x, :z, :x, :y]
+@inferred longest_common_subsequence(a, b)
+seq, a_range, b_range = longest_common_subsequence(a, b)
+@test seq == [:x, :x, :y]
+@test typeof(seq) == Vector{Symbol}
+@test a_range == 2:4
+@test b_range == 1:4
+
+# Test type-stability for different element types
+a = [1.0, 2.0, 3.0, 4.0]
+b = [1, 3]
+@inferred longest_common_subsequence(a, b)
+seq, a_range, b_range = longest_common_subsequence(a, b)
+@test typeof(seq) == Vector{promote_type(Float64, Int)}
+@test seq == [1.0, 3.0]
+
 # -------
 
 a = "abc"


### PR DESCRIPTION
I've made a few minor changes to make longest_common_subsequence type-stable for array inputs. This required making a positional argument-only version of `longest_common_subsequence`, which the keyword-argument version can call. 

I've also taken the liberty of adding all the supported julia versions to your travis config, and I've turned off OSX builds on Travis, which are a fairly scarce resource and almost certainly not going to catch anything that Linux will miss in a simple pure-julia package like this. Happy to change that if you don't agree. 